### PR TITLE
Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "pmill/clockwork-php",
+    "name": "mediaburst/clockwork-php",
     "autoload": {
         "classmap": ["/"]
     }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "pmill/clockwork-php",
+    "autoload": {
+        "classmap": ["/"]
+    }
+}


### PR DESCRIPTION
Added composer.json file for installs via packagist (https://packagist.org/). You guys will need to create an account on packagist and add this repository, this should allow installs via `composer require mediaburst/clockwork-php`.
